### PR TITLE
Fixed package search if Opera is the default browser

### DIFF
--- a/app/src/main/java/top/rootu/lampa/MainActivity.kt
+++ b/app/src/main/java/top/rootu/lampa/MainActivity.kt
@@ -2260,7 +2260,7 @@ class MainActivity : BaseActivity(),
     }
 
     private fun getAvailablePlayers(intent: Intent): List<ResolveInfo> {
-        return packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL)
             .filterNot { info ->
                 info.activityInfo.packageName.lowercase() in PLAYERS_BLACKLIST
             }


### PR DESCRIPTION
Empty player's list with MATCH_DEFAULT_ONLY
The problem may occur after installing [Opera](https://play.google.com/store/apps/details?id=com.opera.browser) browser as default(in onboarding screen)
After removing Opera it worked fine again

Another workaround(not tested) remove https://github.com/lampa-app/LAMPA/blob/main/app/src/main/java/top/rootu/lampa/MainActivity.kt#L219