### PR TITLE
Add external search via SearchManager.QUERY intent

### DIFF
--- a/app/src/main/java/top/rootu/lampa/MainActivity.kt
+++ b/app/src/main/java/top/rootu/lampa/MainActivity.kt
@@ -1104,6 +1104,25 @@ class MainActivity : BaseActivity(),
                 "open_settings" -> showMenuDialog()
             }
         }
+        // Handle an external search query (e.g. from a voice assistant or a
+        // launcher): open LAMPA's own search screen prefilled with the query
+        // via the public Lampa.Search API. If a search screen is already open
+        // (a repeated external query), close it first — Lampa.Search.open() is
+        // not idempotent and would stack a new search over the previous one.
+        // runVoidJsFunc queues the call until the web app is ready, so a cold
+        // start is fine.
+        intent.getStringExtra(SearchManager.QUERY)?.let { query ->
+            if (query.isNotBlank()) {
+                val escaped = query.replace("\\", "\\\\").replace("'", "\\'")
+                val opener = "(function(q){" +
+                        "if(!window.Lampa||!Lampa.Search)return;" +
+                        "try{if(document.body&&document.body.classList" +
+                        ".contains('search--open'))Lampa.Search.close();}catch(e){}" +
+                        "Lampa.Search.open({input:q});" +
+                        "})"
+                runVoidJsFunc(opener, "'$escaped'")
+            }
+        }
         // Fix initial focus
         browser?.setFocus()
     }


### PR DESCRIPTION
## Что делает

`processIntent()` читает стандартный extra `SearchManager.QUERY`. Если он
есть — открывает штатный поиск LAMPA с этим запросом через `Lampa.Search`.
Если поиск уже открыт — сначала закрывает его (иначе `Lampa.Search.open()`
наложит новый поиск поверх старого).

## Зачем

Я разрабатываю альтернативный голосовой поиск для Android TV — **ATV-RU
Поиск**. Он распознаёт речь и ищет контент по установленным приложениям.

Сейчас LAMPA принимает снаружи только открытие готовой карточки (id,
TMDB-URL, GLOBALSEARCH), но не текстовый поисковый запрос — поэтому
распознанный голосовой запрос нельзя передать в поиск LAMPA, можно только
открыть карточку. Очень хотелось бы иметь полную поддержку LAMPA — эта
правка её даёт.

## Как вызвать

Intent на `top.rootu.lampa/.MainActivity` с
`putExtra(SearchManager.QUERY, "текст запроса")`.

---

## What

`processIntent()` reads the standard `SearchManager.QUERY` extra. If present,
it opens LAMPA's own search with that query via `Lampa.Search`. If a search
is already open, it is closed first (otherwise `Lampa.Search.open()` stacks a
new search over the old one).

## Why

I'm building an alternative voice search for Android TV — **ATV-RU Поиск**.
It recognizes speech and searches content across installed apps.

LAMPA currently accepts only opening a ready card from outside (id, TMDB URL,
GLOBALSEARCH), not a plain text search query — so a recognized voice query
cannot be handed to LAMPA's own search, only a card can be opened. I'd really
like full LAMPA support, and this change enables it.

## How to invoke

Intent to `top.rootu.lampa/.MainActivity` with
`putExtra(SearchManager.QUERY, "search text")`.
