### PR TITLE
Add dataType:base64 to native HTTP bridge for binary-safe responses

### DIFF
--- a/app/src/main/java/top/rootu/lampa/AndroidJS.kt
+++ b/app/src/main/java/top/rootu/lampa/AndroidJS.kt
@@ -325,6 +325,8 @@ class AndroidJS(private val mainActivity: MainActivity, private val browser: Bro
                 ?: throw IllegalArgumentException("URL cannot be empty")
             val data = jsonObject.opt("post_data")
             val returnHeaders = jsonObject.optBoolean("returnHeaders", false)
+             // Optional dataType: "base64" forces binary-safe response encoding.
+            val dataType = jsonObject.optString("dataType").takeIf { it.isNotEmpty() }
             val timeout = jsonObject.optInt("timeout", 15000).coerceAtLeast(1000)
             val headers = jsonObject.optJSONObject("headers")?.let {
                 JSONObject(it.toString()) // Create a copy to avoid modifying the original
@@ -373,10 +375,10 @@ class AndroidJS(private val mainActivity: MainActivity, private val browser: Bro
                     return try {
                         val responseJSON = if (finalRequestContent.isEmpty()) {
                             // GET
-                            http.Get(url, finalHeaders, timeout)
+                            http.Get(url, finalHeaders, timeout, dataType)
                         } else {
                             // POST
-                            http.Post(url, finalRequestContent, finalHeaders, timeout)
+                            http.Post(url, finalRequestContent, finalHeaders, timeout, dataType)
                         }
                         reqResponse[returnI.toString()] = if (returnHeaders) {
                             responseJSON.toString()

--- a/app/src/main/java/top/rootu/lampa/net/Http.java
+++ b/app/src/main/java/top/rootu/lampa/net/Http.java
@@ -1,5 +1,6 @@
 package top.rootu.lampa.net;
 
+import android.util.Base64;
 import android.util.Log;
 
 import com.btr.proxy.selector.pac.PacProxySelector;
@@ -53,7 +54,7 @@ public class Http {
         return rb;
     }
 
-    private JSONObject getJsonFromResponse(Response response) throws Exception {
+    private JSONObject getJsonFromResponse(Response response, String dataType) throws Exception {
         if (!response.isSuccessful()) {
             this.lastErrorCode = response.code();
             throw new Exception("Invalid response from server: " + response.code() + " " + response.message());
@@ -84,6 +85,15 @@ public class Http {
             // Avoid OOM
             if (body.contentLength() > MAX_ALLOWED_BODY_SIZE) {
                 json.put("body", "[Response too large, skipped]");
+            } else if ("base64".equalsIgnoreCase(dataType)) {
+                // Binary-safe path: callers (e.g. HLS segment loaders) ask for
+                // dataType:"base64" to bypass body.string()'s UTF-8 charset
+                // decoding, which would replace every byte >= 0x80 with U+FFFD
+                // (low byte 0xfd) and destroy any binary payload like MPEG-TS,
+                // CMAF .m4s, JPEG, MP3, etc. body.bytes() reads the raw byte[]
+                // and Base64 round-trips it as pure ASCII through the JS bridge.
+                json.put("body", Base64.encodeToString(body.bytes(), Base64.NO_WRAP));
+                json.put("encoding", "base64");
             } else {
                 json.put("body", body.string());
             }
@@ -94,6 +104,10 @@ public class Http {
     }
 
     public JSONObject Get(String url, JSONObject headers, int timeout) throws Exception {
+        return Get(url, headers, timeout, null);
+    }
+
+    public JSONObject Get(String url, JSONObject headers, int timeout, String dataType) throws Exception {
         if (!url.toLowerCase().startsWith("http")) {
             this.lastErrorCode = 400;
             throw new Exception("Bad Request (Invalid protocol; use http or https)");
@@ -101,10 +115,14 @@ public class Http {
         Request.Builder rb = getReqBuilder(url, headers);
         OkHttpClient client = HttpHelper.getOkHttpClient(timeout);
         Response response = client.newCall(rb.build()).execute();
-        return getJsonFromResponse(response);
+        return getJsonFromResponse(response, dataType);
     }
 
     public JSONObject Post(String url, String data, JSONObject headers, int timeout) throws Exception {
+        return Post(url, data, headers, timeout, null);
+    }
+
+    public JSONObject Post(String url, String data, JSONObject headers, int timeout, String dataType) throws Exception {
         if (!url.toLowerCase().startsWith("http")) {
             this.lastErrorCode = 400;
             throw new Exception("Bad Request (Invalid protocol; use http or https)");
@@ -117,7 +135,7 @@ public class Http {
         rb.post(requestBody);
         OkHttpClient client = HttpHelper.getOkHttpClient(timeout);
         Response response = client.newCall(rb.build()).execute();
-        return getJsonFromResponse(response);
+        return getJsonFromResponse(response, dataType);
     }
 
     public int getLastErrorCode() {


### PR DESCRIPTION
OkHttp ResponseBody.string() UTF-8-decodes the body, corrupting binary payloads. Add base64 path via body.bytes() + Base64.encodeToString for HLS segment loaders etc.