### PR TITLE
Add support for Just+ Player and extended metadata

### DIFF
--- a/app/src/main/java/top/rootu/lampa/MainActivity.kt
+++ b/app/src/main/java/top/rootu/lampa/MainActivity.kt
@@ -206,6 +206,9 @@ class MainActivity : BaseActivity(),
         private val DDD_PLAYER_PACKAGES = setOf(
             "top.rootu.dddplayer"
         )
+        private val JUSTPLUS_PLAYER_PACKAGES = setOf(
+            "com.justplus.player"
+        )
         private val EXO_PLAYER_PACKAGES = setOf(
             "com.google.android.exoplayer2.demo", // v2, Legacy
             "androidx.media3.demo.main", // v3, current
@@ -2354,6 +2357,17 @@ class MainActivity : BaseActivity(),
                     headers = headers
                 )
             }
+            // Just+ Player
+            in JUSTPLUS_PLAYER_PACKAGES -> {
+                configureJustPlusPlayerIntent(
+                    intent,
+                    playerPackage,
+                    state = state,
+                    videoTitle,
+                    position,
+                    headers = headers
+                )
+            }
             // MX Player
             in MX_PACKAGES -> {
                 configureMxPlayerIntent(
@@ -2657,6 +2671,105 @@ class MainActivity : BaseActivity(),
                     putExtra("thumbnail", item.thumbnail ?: "")
 
                     // Subtitles for single video
+                    item.subtitles?.takeIf { it.isNotEmpty() }?.let { subs ->
+                        val subUris = subs.map { it.url.toUri() }.toTypedArray()
+                        val subNames = subs.map { it.label ?: "Sub" }.toTypedArray()
+
+                        putExtra("subs", subUris)
+                        putExtra("subs.name", subNames)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun configureJustPlusPlayerIntent(
+        intent: Intent,
+        playerPackage: String,
+        state: PlayerStateManager.PlaybackState,
+        videoTitle: String,
+        position: Long,
+        headers: Array<String>? = null
+    ) {
+        val cardImdbId = (state.extras[LAMPA_CARD_KEY] as? String)
+            ?.let { getJson(it, LampaCard::class.java)?.imdb_id }
+            ?.takeIf { it.isNotEmpty() }
+
+        intent.apply {
+            setPackage(playerPackage)
+            putExtra("title", videoTitle)
+            putExtra("return_result", true)
+
+            headers?.let { putExtra("headers", it) }
+
+            when {
+                playerTimeCode == "continue" && position > 0 ->
+                    putExtra("position", position.toInt())
+                playerTimeCode == "again" ->
+                    putExtra("position", 0)
+            }
+
+            if (state.playlist.size > 1) {
+                val urls = ArrayList<Uri>()
+                val titles = ArrayList<String>()
+                val filenames = ArrayList<String>()
+                val thumbnails = ArrayList<String>()
+                val segmentsList = ArrayList<String>()
+                val subtitlesList = ArrayList<Bundle>()
+
+                val seasons = ArrayList<String>()
+                val episodes = ArrayList<String>()
+                val imdbIds = ArrayList<String>()
+
+                state.playlist.forEach { item ->
+                    urls.add(item.url.toUri())
+                    titles.add(item.title ?: "")
+                    filenames.add(item.url.toUri().lastPathSegment ?: "")
+                    thumbnails.add(item.thumbnail ?: "")
+                    segmentsList.add(item.segments ?: "")
+                    seasons.add(item.season?.toString() ?: "")
+                    episodes.add(item.episode?.toString() ?: "")
+                    imdbIds.add(item.imdbId ?: cardImdbId ?: "")
+
+                    val itemSubsBundle = Bundle()
+                    item.subtitles?.takeIf { it.isNotEmpty() }?.let { subs ->
+                        val subUris = subs.map { it.url.toUri() }.toTypedArray()
+                        val subNames = subs.map { it.label ?: "Sub" }.toTypedArray()
+                        itemSubsBundle.putParcelableArray("uris", subUris)
+                        itemSubsBundle.putStringArray("names", subNames)
+                    }
+                    subtitlesList.add(itemSubsBundle)
+                }
+
+                state.currentItem?.let { item ->
+                    setDataAndType(item.url.toUri(), "video/*")
+
+                    item.season?.let { putExtra("season", it) }
+                    item.episode?.let { putExtra("episode", it) }
+                    (item.imdbId ?: cardImdbId)?.let { putExtra("imdb_id", it) }
+                }
+
+                putExtra("video_list", urls.toTypedArray())
+                putStringArrayListExtra("video_list.name", titles)
+                putStringArrayListExtra("video_list.filename", filenames)
+                putStringArrayListExtra("video_list.thumbnail", thumbnails)
+                putStringArrayListExtra("video_list.segments", segmentsList)
+                putStringArrayListExtra("video_list.season", seasons)
+                putStringArrayListExtra("video_list.episode", episodes)
+                putStringArrayListExtra("video_list.imdb_id", imdbIds)
+
+                putParcelableArrayListExtra("video_list.subtitles", subtitlesList)
+
+            } else {
+                state.currentItem?.let { item ->
+                    setDataAndType(item.url.toUri(), "video/*")
+                    putExtra("filename", item.url.toUri().lastPathSegment)
+                    putExtra("thumbnail", item.thumbnail ?: "")
+                    item.segments?.let { putExtra("segments", it) }
+                    item.season?.let { putExtra("season", it) }
+                    item.episode?.let { putExtra("episode", it) }
+                    (item.imdbId ?: cardImdbId)?.let { putExtra("imdb_id", it) }
+
                     item.subtitles?.takeIf { it.isNotEmpty() }?.let { subs ->
                         val subUris = subs.map { it.url.toUri() }.toTypedArray()
                         val subNames = subs.map { it.label ?: "Sub" }.toTypedArray()

--- a/app/src/main/java/top/rootu/lampa/PlayerStateManager.kt
+++ b/app/src/main/java/top/rootu/lampa/PlayerStateManager.kt
@@ -89,6 +89,10 @@ class PlayerStateManager(context: Context) {
      * @property timeline Playback timeline information
      * @property quality Available quality variants
      * @property subtitles Available subtitle tracks
+     * @property segments Raw skip/ad segments JSON (as received from Lampa)
+     * @property season Season number, if the item is a TV episode (may be absent)
+     * @property episode Episode number, if the item is a TV episode (may be absent)
+     * @property imdbId IMDb id from the card (may be absent)
      */
     data class PlaylistItem(
         val url: String,
@@ -96,7 +100,11 @@ class PlayerStateManager(context: Context) {
         val thumbnail: String? = null,
         val timeline: Timeline? = null,
         val quality: Map<String, String>? = null,
-        val subtitles: List<Subtitle>? = null
+        val subtitles: List<Subtitle>? = null,
+        val segments: String? = null,
+        val season: Int? = null,
+        val episode: Int? = null,
+        val imdbId: String? = null
     ) {
         /**
          * Data class representing playback timeline information.
@@ -706,7 +714,16 @@ class PlayerStateManager(context: Context) {
             thumbnail = optString("thumbnail").takeIf { it.isNotEmpty() },
             timeline = optJSONObject("timeline")?.toTimeline(),
             quality = optJSONObject("quality")?.toQualityMap(),
-            subtitles = optJSONArray("subtitles")?.toSubtitles()
+            subtitles = optJSONArray("subtitles")?.toSubtitles(),
+            segments = optJSONObject("segments")?.toString(),
+
+            // Optional TV episode info — absent for movies / single files.
+            season = if (has("season") && !isNull("season")) optInt("season") else null,
+            episode = if (has("episode") && !isNull("episode")) optInt("episode") else null,
+
+            // IMDb id: a persisted flat field, else from the card (data.card.imdb_id) if present.
+            imdbId = optString("imdb_id").takeIf { it.isNotEmpty() }
+                ?: optJSONObject("card")?.optString("imdb_id")?.takeIf { it.isNotEmpty() }
         )
     }
 
@@ -779,6 +796,9 @@ class PlayerStateManager(context: Context) {
                     subs.forEach { put(it.toJson()) }
                 })
             }
+            season?.let { put("season", it) }
+            episode?.let { put("episode", it) }
+            imdbId?.let { put("imdb_id", it) }
         }
     }
 


### PR DESCRIPTION
Интеграция с форком Just, в котором добавлена поддержка плейлистов и таймкодов от лампы

https://github.com/just-plus-player/just-plus-player/

<img width="1280" height="573" alt="image" src="https://github.com/user-attachments/assets/24a30ad8-c177-4806-9181-23811ae0bf96" />
<img width="1280" height="573" alt="image" src="https://github.com/user-attachments/assets/e9252a96-a551-4e11-98db-399e3b0fc7b8" />
