### PR TITLE
Add UA Player extended metadata support

### DIFF
--- a/app/src/main/java/top/rootu/lampa/MainActivity.kt
+++ b/app/src/main/java/top/rootu/lampa/MainActivity.kt
@@ -207,7 +207,8 @@ class MainActivity : BaseActivity(),
             "top.rootu.dddplayer"
         )
         private val JUSTPLUS_PLAYER_PACKAGES = setOf(
-            "com.justplus.player"
+            "com.justplus.player",
+            "com.lampaua.player"
         )
         private val EXO_PLAYER_PACKAGES = setOf(
             "com.google.android.exoplayer2.demo", // v2, Legacy


### PR DESCRIPTION
## What changed

- Added `com.lampaua.player` to the existing `JUSTPLUS_PLAYER_PACKAGES` allowlist.
- UA Player therefore receives the same extended playlist and episode metadata Intent contract as Just+ Player.

## Why

UA Player is an open-source Just Player-based external player for Lampa. Its Android package differs from Just+, so LAMPA currently falls back to the generic external-player Intent and does not send `video_list.*`, episode metadata, thumbnails, subtitles, or skip segments.

Recognizing the package in the existing Just+ branch avoids duplicating Intent construction and keeps the protocol consistent between compatible players.

## Open source

The complete UA Player Android source code is now public:

https://github.com/Hlushok/lampaua-player

The repository includes the official `video_list.*` receiver implementation, the legacy LampaUA JSON bridge, build instructions, resources and license. Lampac server modules are separate and are not part of the player repository.

## Impact

- No behavior changes for Just+ Player or other external players.
- UA Player receives extended metadata only when selected.
- UA Player supports both the official `video_list.*` contract and the existing `lampaua.playlist_json` bridge.

## Validation

- `./gradlew :app:compileFullDebugKotlin` — successful for LAMPA.
- UA Player `./gradlew :app:assembleLatestUniversalRelease` — successful.
