### PR TITLE
Keep RCH sync socket alive during external playback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-sdk tools:overrideLibrary="org.xwalk.core, net.gotev.speech, androidx.recommendation, androidx.tvprovider" /> <!-- use older sdk -->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission
         android:name="android.permission.ACCESS_WIFI_STATE"
         tools:ignore="LeanbackUsesWifi" />
@@ -190,6 +192,11 @@
         <service
             android:name=".sched.ContentAlarmManager"
             android:enabled="true" />
+        <service
+            android:name=".PlaybackService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/java/top/rootu/lampa/MainActivity.kt
+++ b/app/src/main/java/top/rootu/lampa/MainActivity.kt
@@ -97,6 +97,7 @@ import top.rootu.lampa.helpers.Prefs.addUrlHistory
 import top.rootu.lampa.helpers.Prefs.appBrowser
 import top.rootu.lampa.helpers.Prefs.appLang
 import top.rootu.lampa.helpers.Prefs.appPlayer
+import top.rootu.lampa.helpers.Prefs.playerKeepConnection
 import top.rootu.lampa.helpers.Prefs.appPrefs
 import top.rootu.lampa.helpers.Prefs.appUrl
 import top.rootu.lampa.helpers.Prefs.bookToRemove
@@ -142,6 +143,7 @@ class MainActivity : BaseActivity(),
     private var browser: Browser? = null
     private var browserInitComplete = false
     private var isMenuVisible = false
+    private var isPlayerLaunching = false // suppress WebView pauseTimers while our external player is open
     private lateinit var loaderView: LottieAnimationView
     private lateinit var resultLauncher: ActivityResultLauncher<Intent>
     private lateinit var speechLauncher: ActivityResultLauncher<Intent>
@@ -243,6 +245,7 @@ class MainActivity : BaseActivity(),
         var delayedVoidJsFunc = mutableListOf<List<String>>()
         var playerTimeCode: String = "continue"
         var playerAutoNext: Boolean = true
+        var keepPlayerConnection: Boolean = true
         var proxyTmdbEnabled: Boolean = false
         var lampaActivity: String = "{}" // JSON
         lateinit var urlAdapter: ArrayAdapter<String>
@@ -265,6 +268,7 @@ class MainActivity : BaseActivity(),
         super.onCreate(savedInstanceState)
         LAMPA_URL = appUrl
         SELECTED_PLAYER = appPlayer
+        keepPlayerConnection = playerKeepConnection
         logDebug("onCreate SELECTED_BROWSER: $SELECTED_BROWSER")
         logDebug("onCreate LAMPA_URL: $LAMPA_URL")
         logDebug("onCreate SELECTED_PLAYER: $SELECTED_PLAYER")
@@ -294,6 +298,9 @@ class MainActivity : BaseActivity(),
 
     override fun onResume() {
         super.onResume()
+        isPlayerLaunching = false // returned to foreground; player (if any) is closed
+        browser?.setKeepVisible(false) // restore normal visibility handling
+        PlaybackService.stop(this) // no longer need to hold the process foreground
         hideSystemUI()
         if (!isTvBox) setupFab()
         // Try to initialize again when the user completed updating and
@@ -313,12 +320,15 @@ class MainActivity : BaseActivity(),
     }
 
     override fun onPause() {
-        if (browserInitComplete)
+        // Keep JS timers (and the RCH socket heartbeat) alive while our external player is open,
+        // but only when the user enabled it. Home/real backgrounding still pauses as before.
+        if (browserInitComplete && !(isPlayerLaunching && keepPlayerConnection))
             browser?.pauseTimers()
         super.onPause()
     }
 
     override fun onDestroy() {
+        PlaybackService.stop(this)
         if (browserInitComplete) {
             browser?.apply {
                 // Destroy only if not already destroyed
@@ -336,8 +346,11 @@ class MainActivity : BaseActivity(),
 
     // handle user pressed Home
     override fun onUserLeaveHint() {
-        logDebug("onUserLeaveHint()")
-        if (browserInitComplete)
+        logDebug("onUserLeaveHint() isPlayerLaunching=$isPlayerLaunching")
+        // Launching our external player also triggers onUserLeaveHint (startActivity sets the
+        // userLeaving flag) BEFORE onPause. Skip pausing there so the RCH socket heartbeat
+        // survives playback. Real Home/leave (isPlayerLaunching == false) still pauses & clears.
+        if (browserInitComplete && !(isPlayerLaunching && keepPlayerConnection))
             browser?.apply {
                 pauseTimers()
                 clearCache(true)
@@ -556,6 +569,9 @@ class MainActivity : BaseActivity(),
     // mpv http://mpv-android.github.io/mpv-android/intent.html
     // vimu https://www.vimu.tv/player-api
     private fun handlePlayerResult(result: androidx.activity.result.ActivityResult) {
+        isPlayerLaunching = false // player closed, returning result
+        browser?.setKeepVisible(false)
+        PlaybackService.stop(this)
         val data: Intent? = result.data
         val videoUrl: String = data?.data?.toString() ?: "null"
         val resultCode = result.resultCode
@@ -1338,6 +1354,14 @@ class MainActivity : BaseActivity(),
                 icon = R.drawable.round_settings_backup_restore_24
             ),
             MenuItem(
+                title = getString(
+                    if (keepPlayerConnection) R.string.keep_connection_disable
+                    else R.string.keep_connection_enable
+                ),
+                action = "toggleKeepConnection",
+                icon = R.drawable.round_link_24
+            ),
+            MenuItem(
                 title = getString(R.string.exit),
                 action = "appExit",
                 icon = R.drawable.round_exit_to_app_24
@@ -1378,6 +1402,11 @@ class MainActivity : BaseActivity(),
                     }
 
                     "showBackupDialog" -> showBackupDialog()
+                    "toggleKeepConnection" -> {
+                        keepPlayerConnection = !keepPlayerConnection
+                        playerKeepConnection = keepPlayerConnection // persist to prefs
+                        showMenuDialog() // reopen so the item reflects the new state
+                    }
                     "appExit" -> appExit()
                 }
             }
@@ -3150,8 +3179,22 @@ class MainActivity : BaseActivity(),
     private fun launchPlayer(intent: Intent) {
         try {
             debugLogIntentData(TAG, intent)
+            // Mark that the upcoming onPause() is caused by launching our external player,
+            // so we can keep the WebView JS timers (RCH socket heartbeat) alive.
+            isPlayerLaunching = true
+            // Keep the page reported as visible to the web engine so Lampa doesn't pause its
+            // own timers on DOM visibilitychange while the player is in front.
+            if (keepPlayerConnection) {
+                browser?.setKeepVisible(true)
+                // Foreground service keeps the process out of the OEM/Android background
+                // freezer so the WebView RCH socket survives while the player is on top.
+                PlaybackService.start(this)
+            }
             resultLauncher.launch(intent)
         } catch (e: Exception) {
+            isPlayerLaunching = false // no player launched -> onPause won't be a player launch
+            browser?.setKeepVisible(false)
+            PlaybackService.stop(this)
             logDebug("Failed to launch player: ${e.message}")
             App.toast(R.string.no_launch_player, true)
         }

--- a/app/src/main/java/top/rootu/lampa/PlaybackService.kt
+++ b/app/src/main/java/top/rootu/lampa/PlaybackService.kt
@@ -1,0 +1,85 @@
+package top.rootu.lampa
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import top.rootu.lampa.helpers.Helpers.debugLog
+
+/**
+ * Foreground service that keeps the app process at foreground importance while an external
+ * video player is in front. Without it, aggressive OEM/Android background freezers
+ * (e.g. OPPO/OnePlus HANS / Osense, Android Cached Apps Freezer) suspend the whole process
+ * — including the WebView renderer thread — which stops the RCH socket heartbeat and drops
+ * the connection during playback.
+ *
+ * Started/stopped by [MainActivity] around external playback, gated by the user setting.
+ */
+class PlaybackService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIF_ID, buildNotification())
+        debugLog(TAG, "started")
+        return START_NOT_STICKY
+    }
+
+    private fun buildNotification(): Notification {
+        val channelId = ensureChannel()
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.keep_connection_notification))
+            .setSmallIcon(R.drawable.lampa_icon)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setShowWhen(false)
+            .build()
+    }
+
+    private fun ensureChannel(): String {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (nm.getNotificationChannel(CHANNEL_ID) == null) {
+                val channel = NotificationChannel(
+                    CHANNEL_ID,
+                    getString(R.string.keep_connection_channel),
+                    NotificationManager.IMPORTANCE_LOW
+                ).apply { setShowBadge(false) }
+                nm.createNotificationChannel(channel)
+            }
+        }
+        return CHANNEL_ID
+    }
+
+    companion object {
+        private const val TAG = "PlaybackService"
+        private const val CHANNEL_ID = "playback_keepalive"
+        private const val NOTIF_ID = 42
+
+        fun start(context: Context) {
+            try {
+                val intent = Intent(context, PlaybackService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                    context.startForegroundService(intent)
+                else
+                    context.startService(intent)
+            } catch (e: Exception) {
+                debugLog(TAG, "start failed: ${e.message}")
+            }
+        }
+
+        fun stop(context: Context) {
+            try {
+                context.stopService(Intent(context, PlaybackService::class.java))
+            } catch (e: Exception) {
+                debugLog(TAG, "stop failed: ${e.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/top/rootu/lampa/browser/Browser.kt
+++ b/app/src/main/java/top/rootu/lampa/browser/Browser.kt
@@ -164,6 +164,15 @@ interface Browser {
      * methods may be called on this WebView after destroy.
      */
     fun destroy()
+
+    /**
+     * Keep the web engine reporting the page as "visible" even while the host Activity is
+     * backgrounded (e.g. an external player is in front). This prevents the DOM
+     * `visibilitychange` -> hidden event, so the web app (Lampa) does not pause its own
+     * timers / RCH socket heartbeat during playback. No-op on engines that don't support it.
+     */
+    fun setKeepVisible(keep: Boolean) {}
+
     fun setBackgroundColor(color: Int)
     fun canGoBack(): Boolean
     fun goBack()

--- a/app/src/main/java/top/rootu/lampa/browser/LampaWebView.kt
+++ b/app/src/main/java/top/rootu/lampa/browser/LampaWebView.kt
@@ -1,0 +1,26 @@
+package top.rootu.lampa.browser
+
+import android.content.Context
+import android.util.AttributeSet
+import android.webkit.WebView
+
+/**
+ * WebView that can keep reporting itself as window-visible while the host Activity is
+ * backgrounded. When [keepVisible] is true, Chromium keeps `document.visibilityState` as
+ * 'visible', so the loaded web app (Lampa) does not fire `visibilitychange` and does not
+ * pause its own timers / RCH socket heartbeat while an external video player is in front.
+ *
+ * Used together with skipping [WebView.pauseTimers] during external playback.
+ */
+class LampaWebView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : WebView(context, attrs, defStyleAttr) {
+
+    var keepVisible = false
+
+    override fun onWindowVisibilityChanged(visibility: Int) {
+        super.onWindowVisibilityChanged(if (keepVisible) VISIBLE else visibility)
+    }
+}

--- a/app/src/main/java/top/rootu/lampa/browser/SysView.kt
+++ b/app/src/main/java/top/rootu/lampa/browser/SysView.kt
@@ -292,6 +292,10 @@ class SysView(override val mainActivity: MainActivity, override val viewResId: I
         browser?.clearCache(includeDiskFiles)
     }
 
+    override fun setKeepVisible(keep: Boolean) {
+        (browser as? LampaWebView)?.keepVisible = keep
+    }
+
     override fun destroy() {
         browser?.let {
             // Remove from parent if attached

--- a/app/src/main/java/top/rootu/lampa/helpers/Prefs.kt
+++ b/app/src/main/java/top/rootu/lampa/helpers/Prefs.kt
@@ -27,6 +27,7 @@ object Prefs {
     private const val APP_URL_HISTORY = "lampa_history"
     private const val APP_PLAYER = "player"
     private const val IPTV_PLAYER = "iptv_player"
+    private const val PLAYER_KEEP_CONN_KEY = "player_keep_connection"
     private const val LAMPA_SOURCE = "source"
     private const val APP_BROWSER = "browser"
     private const val APP_LANG = "lang"
@@ -73,6 +74,11 @@ object Prefs {
     var Context.tvPlayer: String?
         get() = appPrefs.getString(IPTV_PLAYER, "")
         set(player) = appPrefs.edit().putString(IPTV_PLAYER, player).apply()
+
+    // Keep the RCH socket alive while an external player is in front (default on)
+    var Context.playerKeepConnection: Boolean
+        get() = appPrefs.getBoolean(PLAYER_KEEP_CONN_KEY, true)
+        set(value) = appPrefs.edit().putBoolean(PLAYER_KEEP_CONN_KEY, value).apply()
 
     var Context.lampaSource: String
         get() = appPrefs.getString(LAMPA_SOURCE, "tmdb") ?: "tmdb"

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -43,7 +43,7 @@
         app:lottie_loop="true"
         app:lottie_rawRes="@raw/loader" />
 
-    <WebView
+    <top.rootu.lampa.browser.LampaWebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="no_activity_found">Нет приложения, позволяющего открыть ссылку этого типа.</string>
     <string name="no_player_activity_found">Подходящего мультимедиа-плеера не найдено. Пожалуйста, установите плеер из Google Play Store или любого другого источника. Мы рекомендуем Just Player, Vimu Media Player, VLC.</string>
+    <string name="keep_connection_channel">Фоновое соединение</string>
+    <string name="keep_connection_notification">Соединение поддерживается во время просмотра</string>
+    <string name="keep_connection_enable">Включить удержание сокета</string>
+    <string name="keep_connection_disable">Выключить удержание сокета</string>
     <string name="no_torrent_activity_found">Нет приложения для открытия торрент-ссылок. Пожалуйста, установите TorrServe или любое другое приложение, работающее с торрентами.</string>
     <string name="no_youtube_activity_found">Нет приложения для открытия ссылок YouTube. Пожалуйста, установите приложение YouTube.</string>
     <string name="no_launch_player">Lampa: Выбранный плеер не поддерживает воспроизведение этого видео</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="no_activity_found">Немає додатка для відкриття цього типу посилань.</string>
     <string name="no_player_activity_found">Не знайдено відповідного мультимедійного програвача. Встановіть плеєр з Google Play або будь-якого іншого джерела. Ми рекомендуємо Just Player, Vimu Media Player, VLC.</string>
+    <string name="keep_connection_channel">Фонове зʼєднання</string>
+    <string name="keep_connection_notification">Зʼєднання підтримується під час перегляду</string>
+    <string name="keep_connection_enable">Увімкнути утримання сокета</string>
+    <string name="keep_connection_disable">Вимкнути утримання сокета</string>
     <string name="no_torrent_activity_found">Немає додатка для відкриття торрент-посилань. Встановіть TorrServe або будь-який інший додаток, що працює з торрентами.</string>
     <string name="no_youtube_activity_found">Немає додатка для відкриття посилань YouTube. Встановіть додаток YouTube.</string>
     <string name="no_launch_player">Обраний плеєр не підтримує відтворення цього відео</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="no_activity_found">​​没有应用程序可以打开此类链接。</string>
     <string name="no_player_activity_found">​​未找到匹配的播放器。请从 Google Play 商店或任何其他来源安装播放器。我们推荐 Just Player、Vimu Media Player、VLC。</string>
+    <string name="keep_connection_channel">后台连接</string>
+    <string name="keep_connection_notification">播放期间保持连接</string>
+    <string name="keep_connection_enable">开启保持 socket 打开</string>
+    <string name="keep_connection_disable">关闭保持 socket 打开</string>
     <string name="no_torrent_activity_found">​​没有应用程序可以打开 torrent 链接。请安装 TorrServe 或任何其他支持 torrent 的应用程序。</string>
     <string name="no_youtube_activity_found">​​没有应用程序可以打开 YouTube 链接。请安装 YouTube 应用。</string>
     <string name="no_launch_player">所选播放器不支持该视频</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,10 @@
     <string name="provider_auth" translatable="false">top.rootu.lampa</string>
     <string name="no_activity_found">There is no application to open this type of link.</string>
     <string name="no_player_activity_found">No matching multimedia player found. Please, install player from Google Play Store or any other source. We recommend Just Player, Vimu Media Player, VLC.</string>
+    <string name="keep_connection_channel">Background connection</string>
+    <string name="keep_connection_notification">Keeping connection alive during playback</string>
+    <string name="keep_connection_enable">Enable keeping the socket open</string>
+    <string name="keep_connection_disable">Disable keeping the socket open</string>
     <string name="no_torrent_activity_found">There is no application to open torrent links. Please, install TorrServe or any other App working with torrents.</string>
     <string name="no_youtube_activity_found">There is no application to open YouTube links. Please, install YouTube App.</string>
     <string name="no_launch_player">The selected player does not support playing this video</string>


### PR DESCRIPTION
## What

Adds an option that keeps LAMPA's **RCH sync socket** (`nws?id=...`, `rchtype:"web"`)
alive while an **external video player** (Just+ Player, MX, VLC, etc.) is in the
foreground, so remote/sync sessions don't drop during playback.

The option is a native menu item under the app Options menu — **Enable / Disable
keeping the socket open** — persisted in `SharedPreferences` (default **on**),
localized (en/ru/uk/zh).

## Why

When an external player is launched, the web app's RCH socket dies within seconds and
the client sees a "connection dropped" error. Investigation (on-device `logcat`) showed
this is **not** a single bug but **three independent kill-paths**, each of which alone is
enough to stop the ~1/min `ping` heartbeat:

1. **`WebView.pauseTimers()`** — called from `onPause()` *and* `onUserLeaveHint()` (the
   latter fires first when `startActivity` sets the user-leaving flag). It freezes all JS
   timers, so the heartbeat stops.
   Log: heartbeat never sent while paused.

2. **DOM Page Visibility** — when the WebView goes off-screen, Chromium fires
   `visibilitychange -> hidden`, and Lampa's own `Timer` module pauses itself.
   Log: `[Timer] visibility change: hidden paused: true`.

3. **OEM/Android background freezer** — the whole app process gets frozen once cached.
   Log (OPPO): `OsenseKillAction ... prevPkgName=com.justplus.lampa ... type=cached ...
   freeze_dur=1500` and `OplusHansManager` R→M→F transitions.

Fixing only one leaves the others active (verified step by step on device), so all three
are addressed together.

## How

Guarded by a single `keepPlayerConnection` flag (the menu toggle), active only while an
external player launched by us is in front — normal Home / backgrounding behaves as before.

- **Skip `pauseTimers()`** in `onPause()` / `onUserLeaveHint()` while our player is open.
- **`LampaWebView`** overrides `onWindowVisibilityChanged` to keep reporting window-visible,
  so `document.visibilityState` never becomes `hidden` and Lampa doesn't self-pause.
- **`PlaybackService`** (foreground service, low-importance notification) keeps the process
  out of the background freezer for the duration of playback.

The flag is set right before `resultLauncher.launch(intent)` and cleared on return
(`onResume` / player result / launch failure).

## Notes

- `targetSdk 28`, so the strict Android 14+ foreground-service type/permission rules don't
  apply; only `FOREGROUND_SERVICE` is needed (a `dataSync` type is declared for forward
  compatibility).
- On very aggressive OEMs (OPPO/Xiaomi/…) users may still need to disable battery
  optimization for the app; the foreground service handles the common case.
- No behavior change when the option is off.
